### PR TITLE
Fix tsconfig for Node resolution

### DIFF
--- a/ts/tsconfig.json
+++ b/ts/tsconfig.json
@@ -8,7 +8,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "bundler",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
@@ -18,6 +18,7 @@
         "name": "next"
       }
     ],
+    "types": ["node"],
     "paths": {
       "@/*": ["./*"]
     }


### PR DESCRIPTION
## Summary
- update TypeScript configuration to use Node module resolution and include Node types

## Testing
- `npm run build` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500002c24883208aa666c00cb6e831